### PR TITLE
Add annotate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'web-console', '~> 2.0', group: :development
 
 group :development, :test do
+  gem 'annotate'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,9 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    annotate (2.7.1)
+      activerecord (>= 3.2, < 6.0)
+      rake (>= 10.4, < 12.0)
     arel (6.0.3)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -204,6 +207,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   byebug
   coffee-rails (~> 4.1.0)
   guard-rspec


### PR DESCRIPTION
This adds the annotate gem. https://github.com/ctran/annotate_models .

This is really helpful because it adds the database fields as comments at the top of the model. Without this gem you have to either look in the database or look at the schema file, which is a hassle. 

```
# == Schema Info
#
# Table name: line_items
#
#  id                  :integer(11)    not null, primary key
#  quantity            :integer(11)    not null
#  product_id          :integer(11)    not null
#  unit_price          :float
#  order_id            :integer(11)
#

 class LineItem < ActiveRecord::Base
   belongs_to :product
  . . . 
```

As a part of adding models. We should remember to run `annotate` in the command line to update with these comments. 
